### PR TITLE
add missing envs

### DIFF
--- a/.env.erb
+++ b/.env.erb
@@ -15,3 +15,4 @@ S3_REGION=<%= secrets['S3_REGION'] %>
 S3_BUCKET=<%= secrets['S3_BUCKET'] %>
 SIDEKIQ_PASSWORD=<%= secrets['SIDEKIQ_PASSWORD'] %>
 SIDEKIQ_REDIS_URL=<%= secrets['SIDEKIQ_REDIS_URL'] %>
+SECRET_KEY_BASE=<%= secrets['SECRET_KEY_BASE'] %>

--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,6 @@
 SERVER_HOST=http://localhost:3000
 FRONTEND_URL=http://localhost:3000
-JWT_SECRET=example_secret_signature
+JWT_SECRET=example_secret_signature # generate one with `SecureRandom.hex(32)`
 MAILER_SENDER=info@rails-api.com
 REDIS_URL=redis://localhost:6379/0
 S3_ACCESS_KEY_ID=sample
@@ -9,6 +9,7 @@ S3_REGION=us-east-1
 S3_BUCKET=sample_bucket
 SIDEKIQ_PASSWORD=sample_password
 SIDEKIQ_REDIS_URL=redis://localhost:6379/0
+SECRET_KEY_BASE=sample # generate one with `SecureRandom.hex(32)`
 
 # required for kamal deployment
 AWS_ACCOUNT_ID=account_id_from_aws_ekr

--- a/.env.staging.erb
+++ b/.env.staging.erb
@@ -15,3 +15,4 @@ S3_REGION=<%= secrets['S3_REGION'] %>
 S3_BUCKET=<%= secrets['S3_BUCKET'] %>
 SIDEKIQ_PASSWORD=<%= secrets['SIDEKIQ_PASSWORD'] %>
 SIDEKIQ_REDIS_URL=<%= secrets['SIDEKIQ_REDIS_URL'] %>
+SECRET_KEY_BASE=<%= secrets['SECRET_KEY_BASE'] %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,5 +37,8 @@ module RailsApi
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+
+    config.require_master_key = false
+    config.read_encrypted_secrets = false
   end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -81,3 +81,6 @@ test:
 #
 production:
   <<: *default
+
+staging:
+  <<: *default

--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -42,6 +42,7 @@ env:
     - S3_BUCKET
     - SIDEKIQ_PASSWORD
     - SIDEKIQ_REDIS_URL
+    - SECRET_KEY_BASE
 
 # Use a different ssh user than root
 ssh:

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -42,6 +42,7 @@ env:
     - S3_BUCKET
     - SIDEKIQ_PASSWORD
     - SIDEKIQ_REDIS_URL
+    - SECRET_KEY_BASE
 
 # Use a different ssh user than root
 ssh:


### PR DESCRIPTION
### Description

- Add `SECRET_KEY_BASE` env 

---

### Notes

This fixes the deploy, where an exception is raised when running `rails s`, saying that secret_key_base is needed.
