### PR TITLE
[FIX] Prevent CSRF check, fix for devise api controllers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  protect_from_forgery with: :null_session, if: -> { request.format.json? }
 end


### PR DESCRIPTION
### Description

- Because all devise controllers inherit from ApplicationController, then for requests of format json, the CSRF check has to be skipped.

---

### Notes

- The error does not appear in specs, but when testing the auth endpoints manually with curl
