### PR TITLE
add mailer components

### DIFF
--- a/.rubocop.todo.yml
+++ b/.rubocop.todo.yml
@@ -1,0 +1,3 @@
+Style/OptionalArguments:
+  Exclude:
+    - 'app/mailers/components/**/*.rb'

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ApplicationMailer < ActionMailer::Base
+  include Components
+
   default from: ENV.fetch('MAILER_SENDER', 'info@rails-api.com')
   layout 'mailer'
 end

--- a/app/mailers/components.rb
+++ b/app/mailers/components.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Components
+  extend ActiveSupport::Concern
+
+  included do
+    helper_method :frontend_url
+  end
+
+  # @param path [String, nil]
+  # @return [String]
+  #  Returns the frontend URL with the given path safely appended.
+  def frontend_url(path = nil)
+    url = ENV.fetch('FRONTEND_URL')
+    path ? [url, path].join('/').gsub(%r{(?<!:)//}, '/') : url
+  end
+end

--- a/app/mailers/components/align.rb
+++ b/app/mailers/components/align.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Components
+  class Align < Base
+    def initialize(align)
+      super()
+      @align = align
+
+      raise ArgumentError, 'align must be :left, :right or :center' unless %i[left right center].include?(@align)
+    end
+
+    def style = "text-align: #{@align};"
+
+    def template(&)
+      tag.div(content, style:)
+    end
+  end
+end

--- a/app/mailers/components/base.rb
+++ b/app/mailers/components/base.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Components
+  class Base
+    include ActionView::Helpers::CaptureHelper
+
+    attr_reader :view_context
+
+    delegate :capture, :tag, :content_tag, to: :view_context
+    delegate_missing_to :view_context
+
+    class_attribute :slots, default: {}
+
+    def self.slot(name)
+      class_eval <<-RUBY, __FILE__, __LINE__ + 1
+        # def header(&block)
+        #   slots[:header] = block
+        # end
+        #
+        # def header_content
+        #   capture(&slots[:header]) if slots[:header]
+        # end
+        def #{name}(&block)
+          slots[:#{name}] = block
+        end
+
+        def #{name}_content
+          capture(&slots[:#{name}]) if slots[:#{name}]
+        end
+      RUBY
+    end
+
+    def slots
+      self.class.slots
+    end
+
+    def template
+      raise NotImplementedError
+    end
+
+    def content
+      @content_block
+    end
+
+    def helpers
+      return view_context if view_context.present?
+
+      raise ArgumentError, 'helpers cannot be used during initialization, as it depends on the view context'
+    end
+
+    def render_in(view_context, &block)
+      @view_context = view_context
+
+      @content_block = capture { block.call(self) } if block_given?
+      template
+    end
+  end
+end

--- a/app/mailers/components/button.rb
+++ b/app/mailers/components/button.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Components
+  class Button < Base
+    COLORS = {
+      primary: 'background-color: #007bff; border: 1px solid #007bff;',
+      secondary: 'background-color: #6c757d; border: 1px solid #6c757d;',
+      danger: 'background-color: #dc3545; border: 1px solid #dc3545;'
+    }.freeze
+    SIZES = {
+      sm: 'padding: 4px 8px; font-size: 12px;',
+      md: 'padding: 6px 12px; font-size: 14px;',
+      lg: 'padding: 8px 16px; font-size: 16px;'
+    }.freeze
+
+    def initialize(text = nil, url, color: :primary, size: :md)
+      super()
+      @text = text
+      @url = url
+      @color = color
+      @size = size
+
+      raise ArgumentError, 'color must be :primary, :secondary or :danger' unless %i[primary secondary danger].include?(color)
+      raise ArgumentError, 'size must be :sm, :md or :lg' unless %i[sm md lg].include?(size)
+    end
+
+    def style
+      base_style = 'color: #fff; border-color: #007bff; border-radius: 4px; text-decoration: none; display: inline-block;'
+      base_style += COLORS[@color]
+      base_style + SIZES[@size]
+    end
+
+    def text
+      content.presence || @text
+    end
+
+    def template(&)
+      tag.a(text, href: @url, style:)
+    end
+  end
+end

--- a/app/mailers/components/code/block.rb
+++ b/app/mailers/components/code/block.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Components
+  module Code
+    class Block < Base
+      def initialize(code)
+        super()
+        @code = code
+      end
+
+      def style
+        'display: block; padding: 10px; background-color: #f4f4f4; border-radius: 5px;'
+      end
+
+      def template(&)
+        tag.pre do
+          tag.code(@code, style:)
+        end
+      end
+    end
+  end
+end

--- a/app/mailers/components/code/inline.rb
+++ b/app/mailers/components/code/inline.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Components
+  module Code
+    class Inline < Base
+      def initialize(code)
+        super()
+        @code = code
+      end
+
+      def style
+        'padding: 2px 5px; background-color: #f4f4f4; border-radius: 5px;'
+      end
+
+      def template(&)
+        tag.code(@code, style:)
+      end
+    end
+  end
+end

--- a/app/mailers/components/divider.rb
+++ b/app/mailers/components/divider.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Components
+  class Divider < Base
+    def style = 'border: none; border-top: 1px solid #ddd; margin: 20px 0;'
+
+    def template(&)
+      tag.hr(style:)
+    end
+  end
+end

--- a/app/mailers/components/heading.rb
+++ b/app/mailers/components/heading.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Components
+  class Heading < Base
+    LEVELS = [
+      'font-size: 32px;',
+      'font-size: 24px;',
+      'font-size: 20px;',
+      'font-size: 16px;',
+      'font-size: 14px;',
+      'font-size: 12px;'
+    ].freeze
+    def initialize(text = nil, level: 1, align: :center)
+      super()
+      @text = text
+      @level = level
+      @align = align
+
+      raise ArgumentError, 'level must be 1, 2, 3, 4, 5 or 6' unless (1..6).include?(level)
+      raise ArgumentError, 'align must be :left, :right or :center' unless %i[left right center].include?(align)
+    end
+
+    def text
+      content.presence || @text
+    end
+
+    def style
+      "text-align: #{@align}; font-weight: bold;" + LEVELS[@level - 1]
+    end
+
+    def template(&)
+      tag.send("h#{@level}", text, style:)
+    end
+  end
+end

--- a/app/mailers/components/layouts/main.rb
+++ b/app/mailers/components/layouts/main.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Components
+  module Layouts
+    class Main < Base
+      slot :header
+      slot :main
+      slot :footer
+
+      def root_style
+        'max-width: 600px; margin: 20px auto 0 auto; padding: 20px 30px; background-color: #fff; border-radius: 5px; box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);'
+      end
+
+      def template(&)
+        tag.div(style: root_style) do
+          content_tag(:div, style: 'vertical-align: middle;') do
+            concat tag.header(header_content)
+            concat tag.main(main_content)
+            concat render Divider.new
+            concat tag.footer(footer_content)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/mailers/components/link.rb
+++ b/app/mailers/components/link.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Components
+  class Link < Base
+    VARIANTS = {
+      regular: 'font-size: 14px; color: #3498db;',
+      strong: 'font-size: 16px; font-weight: bold; color: #3498db;',
+      muted: 'font-size: 14px; color: #666;'
+    }.freeze
+
+    def initialize(text = nil, url, variant: :regular)
+      super()
+      @text = text
+      @url = url
+      @variant = variant
+    end
+
+    def style
+      VARIANTS[@variant]
+    end
+
+    def text
+      content.presence || @text
+    end
+
+    def template(&)
+      tag.a(text, href: @url, style:)
+    end
+  end
+end

--- a/app/mailers/components/spacer.rb
+++ b/app/mailers/components/spacer.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Components
+  class Spacer < Base
+    def style = 'height: 20px;'
+
+    def template(&)
+      tag.div(nil, style:)
+    end
+  end
+end

--- a/app/mailers/components/text.rb
+++ b/app/mailers/components/text.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Components
+  class Text < Base
+    VARIANTS = {
+      regular: 'color: #333;',
+      muted: 'color: #666;',
+      strong: 'font-weight: bold; color: #333;'
+    }.freeze
+    SIZES = {
+      sm: 'font-size: 12px;',
+      md: 'font-size: 14px;',
+      lg: 'font-size: 16px;'
+    }.freeze
+
+    def initialize(text = nil, align: :left, variant: :regular, size: :md)
+      super()
+      @text = text
+      @align = align
+      @variant = variant
+      @size = size
+
+      raise ArgumentError, 'align must be :left, :right or :center' unless %i[left right center].include?(align)
+      raise ArgumentError, 'variant must be :regular, :muted or :strong' unless %i[regular muted strong].include?(variant)
+      raise ArgumentError, 'size must be :sm, :md or :lg' unless %i[sm md lg].include?(size)
+    end
+
+    def style
+      base_style = "text-align: #{@align};"
+      base_style += VARIANTS[@variant]
+      base_style + SIZES[@size]
+    end
+
+    def text
+      content.presence || @text
+    end
+
+    def template(&)
+      tag.p(text, style:)
+    end
+  end
+end

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,0 +1,7 @@
+<%= render Components::Heading.new("Welcome #{@email}", level: 3) %>
+<%= render Components::Text.new do %>
+  You can confirm your account email through the link below
+<% end %>
+<%= render Components::Align.new(:center) do %>
+  <%= render Components::Button.new('Confirm my account', confirmation_url(@resource, confirmation_token: @token), size: :lg)%>
+<% end %>

--- a/app/views/devise/mailer/email_changed.html.erb
+++ b/app/views/devise/mailer/email_changed.html.erb
@@ -1,0 +1,7 @@
+<%= render Components::Heading.new("Welcome #{@email}", level: 3)
+
+<% if @resource.try(:unconfirmed_email?) %>
+  <%= render Components::Text.new("We're contacting you to notify you that your email is being changed to <%= @resource.unconfirmed_email %>.") %>
+<% else %>
+  <%= render Components::Text.new("We're contacting you to notify you that your email has been changed to <%= @resource.email %>.") %>
+<% end %>

--- a/app/views/devise/mailer/password_change.html.erb
+++ b/app/views/devise/mailer/password_change.html.erb
@@ -1,0 +1,4 @@
+<%= render Components::Heading.new("Welcome #{@email}", level: 3) %>
+<%= render Components::Text.new do %>
+  We're contacting you to notify you that your password has been changed.
+<% end %>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,0 +1,13 @@
+<%= render Components::Heading.new("Welcome #{@email}", level: 3) %>
+<%= render Components::Text.new do %>
+  Someone has requested a link to change your password. You can do this through the link below.
+<% end %>
+<%= render Components::Align.new(:center) do %>
+  <%= render Components::Button.new('Change my password', edit_password_url(@resource, reset_password_token: @token), size: :lg) %>
+<% end %>
+<%= render Components::Text.new do %>
+  If you didn't request this, please ignore this email.
+<% end %>
+<%= render Components::Text.new do %>
+  Your password won't change until you access the link above and create a new one.
+<% end %>

--- a/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/devise/mailer/unlock_instructions.html.erb
@@ -1,0 +1,10 @@
+<%= render Components::Heading.new("Welcome #{@email}", level: 3) %>
+<%= render Components::Text.new do %>
+  Your account has been locked due to an excessive number of unsuccessful sign in attempts.
+<% end %>
+<%= render Components::Text.new do %>
+  Click the link below to unlock your account
+<% end %>
+<%= render Components::Align.new(:center) do %>
+  <%= render Components::Button.new('Unlock my account', unlock_url(@resource, unlock_token: @token), size: :lg) %>
+<% end %>

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -3,11 +3,108 @@
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <style>
-      /* Email styles need to be inline */
+      /* -------------------------------------
+          TYPOGRAPHY
+      ------------------------------------- */
+
+      * {
+        font-family: 'Arial', sans-serif;
+        color: #333;
+      }
+
+      body {
+        margin: 0;
+        padding: 0;
+      }
+
+      table {
+        border-collapse:collapse;
+        mso-table-lspace:0;
+        mso-table-rspace:0;
+      }
+
+      h1 {
+        margin:0.67em 0;
+        font-size:2em;
+      }
+      h2 {
+        margin:0.83em 0;
+        font-size:1.5em;
+      }
+
+      html[dir] h3, h3 {
+        margin:1em 0;
+        font-size:1.17em;
+      }
+
+      span.MsoHyperlink {
+        color: inherit !important;
+        mso-style-priority: 99 !important;
+      }
+
+      span.MsoHyperlinkFollowed {
+        color: inherit !important;
+        mso-style-priority: 99 !important;
+      }
+
+      #root [x-apple-data-detectors=true],
+      a[x-apple-data-detectors=true]{
+        color: inherit !important;
+        text-decoration: inherit !important;
+      }
+
+      u + .body a {
+        color: inherit;
+        text-decoration: none;
+        font-size: inherit;
+        font-weight: inherit;
+        line-height: inherit;
+      }
+
+      .body {
+        word-wrap: normal;
+        word-spacing:normal;
+      }
+
+      div[style*="margin: 16px 0"] {
+        margin: 0!important;
+      }
+
+      #message *{
+        all:revert
+      }
+
+      [data-markjs]{
+        color:inherit;
+        padding:0;
+        background:none;
+      }
+
+      /* Add more styles as needed */
+      <%= content_for(:styles) if content_for?(:styles) %>
     </style>
   </head>
 
   <body>
-    <%= yield %>
+    <%= render Components::Layouts::Main.new do |layout| %>
+      <% layout.header do %>
+        <%= render Components::Heading.new(Rails.application.class.module_parent_name.titleize, level: 2) %>
+      <% end %>
+
+      <% layout.main do %>
+        <%= yield %>
+      <% end %>
+
+      <% layout.footer do %>
+        <%= render Components::Text.new(variant: :muted) do %>
+          To learn how we process data and monitor communications please see our
+          <%= render Components::Link.new('Privacy Policy', frontend_url, variant: :muted) %> and
+          <%= render Components::Link.new('Terms of Service', frontend_url, variant: :muted) %>.
+        <% end %>
+        <%= render Components::Text.new(variant: :muted) do %>
+          &copy; <%= Time.current.year %> <%= Rails.application.class.module_parent_name.titleize %>
+        <% end %>
+      <% end %>
+    <% end %>
   </body>
 </html>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -30,7 +30,7 @@ Devise.setup do |config|
   # config.mailer = 'Devise::Mailer'
 
   # Configure the parent class responsible to send e-mails.
-  # config.parent_mailer = 'ActionMailer::Base'
+  config.parent_mailer = 'ApplicationMailer'
 
   # ==> ORM configuration
   # Load and configure the ORM. Supports :active_record (default) and


### PR DESCRIPTION
### Description

- Introduce Components for building emails fast and pretty that work in emails client (inline style)
- Adds simple structure in `app/views/layouts/mailer.html.erb`, so that every transactional email has the same template
- Adds css normalization on mailer.html.erb for different email clients
- Change `Devise::Mailer` parent class from `ActionMailer::Base` to `ApplicationMailer`, so that the layout and the components can be used in devise transactional emails
- Add `#frontend_url(path=nil)` helper to easily point to paths to the frontend in the emails.
---

### Notes

- This is a custom implementation of github's view components, so as not to bloat the gemfile with more dependencies, which make the app harder to update in the future.
- Example of how the confirmation email looks now:
<img width="751" alt="Screenshot 2024-02-08 at 10 23 36" src="https://github.com/gogrow-dev/rails_api/assets/9309458/5d4b7fd8-86b9-45d3-a3d0-f822962948b4">

