### PR TITLE
[CI] Fix ci for ruby 3.3.3

### DIFF
--- a/.github/workflows/build_lint_test.yml
+++ b/.github/workflows/build_lint_test.yml
@@ -31,6 +31,11 @@ jobs:
         options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - uses: actions/checkout@v3
+
+      - name: Patch for ruby 3.3.3
+        run: |
+          sed -i "/net-pop (0.1.2)/a\      net-protocol" Gemfile.lock
+
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true


### PR DESCRIPTION
### Description

- There's a bug in ruby 3.3.3 and `net-pop` (used in many gems, including rails), where it depends on `net-protocol`, but was removed as a dependency from `net-pop`. This change fixes that for the CI. See [this GH issue](https://github.com/ruby/net-pop/issues/26)
- This was already addressed in the `Dockerfile`.

---

### Notes

- N/A
