### PR TITLE
change staging default log level to debug

### DIFF
--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -4,4 +4,5 @@ require File.expand_path('production.rb', __dir__)
 
 Rails.application.configure do
   config.server_timing = ENV.fetch('SERVER_TIMING', nil).present?
+  config.log_level = ENV.fetch('LOG_LEVEL', :debug).to_sym
 end


### PR DESCRIPTION
### Description

- Change staging default log level to debug. This can still be overriden by setting the `LOG_LEVEL` env.

---

### Notes

- N/A
