### PR TITLE
Add healthcheck request silencer

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,8 @@ require 'action_view/railtie'
 require 'action_cable/engine'
 # require "rails/test_unit/railtie"
 
+require_relative '../lib/middlewares/silence_request'
+
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
@@ -50,6 +52,9 @@ module RailsApi
     config.middleware.use ActionDispatch::Session::CookieStore
     config.middleware.insert_after(Rack::Runtime, Rack::MethodOverride)
     config.middleware.insert_after(ActionDispatch::Cookies, ActionDispatch::Session::CookieStore)
+
+    # Silence requests made to the /up (healthcheck) path
+    config.middleware.insert_before Rails::Rack::Logger, SilenceRequest, path: '/up'
 
     config.require_master_key = false
   end

--- a/lib/middlewares/silence_request.rb
+++ b/lib/middlewares/silence_request.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Taken from https://github.com/rails/rails/pull/52789.
+# Once the app is updated to Rails 8, this file can be removed.
+#
+#
+# Allows you to silence requests made to a specific path.
+# This is useful for preventing recurring requests like healthchecks from clogging the logging.
+# This middleware is used to do just that against the path /up in production by default.
+#
+# Example:
+#
+#   config.middleware.insert_before \
+#     Rails::Rack::Logger, Rails::Rack::SilenceRequest, path: "/up"
+#
+class SilenceRequest
+  def initialize(app, path:)
+    @app = app
+    @path = path
+  end
+
+  def call(env)
+    if env['PATH_INFO'] == @path
+      Rails.logger.silence { @app.call(env) }
+    else
+      @app.call(env)
+    end
+  end
+end


### PR DESCRIPTION
### Description

- Silence `/up` requests made every second by traefik to reduce noise in the logs.

---

### Notes

- N/A
