### PR TITLE
Excluding `middlewares` to autoload lib configuration

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -30,7 +30,7 @@ module RailsApi
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
-    config.autoload_lib(ignore: %w[assets tasks generators])
+    config.autoload_lib(ignore: %w[assets tasks generators middlewares])
 
     # Configuration for the application, engines, and railties goes here.
     #


### PR DESCRIPTION
### Description

Excluding `middlewares` to autoload lib configuration

---

### Notes

N/A